### PR TITLE
show go version

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -65,6 +66,7 @@ func GetFullVersionStr() string {
 	if versionBuildID != "" {
 		ver += fmt.Sprintf(", BuildID: %s", versionBuildID)
 	}
+	ver += ", " + runtime.Version()
 	return ver + ")"
 }
 


### PR DESCRIPTION
With this lb-csi-plugin --version also prints out the go compiler version used:

```bash
lb-csi-plugin --version
lb-csi-plugin 1.6.0 (GitCommit: ed833499, go1.17.2)
```