### PR TITLE
test ci: adding a new PR to check Jenkins trigger

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,7 +6,8 @@ LABEL maintainers="Lightbits Labs" \
       version.lb-csi.git="UNKNOWN" \
       version.lb-csi.build.host="UNKNOWN" \
       version.lb-csi.build.time="UNKNOWN" \
-      version.lb-csi.build.id="UNKNOWN"
+      version.lb-csi.build.id="UNKNOWN" \
+      dummy_label="check a new label is added to docker image"
 # official builds will also carry the following labels:
 #     version.lb-csi.hash
 # while custom builds might also have labels:


### PR DESCRIPTION
this branch is not going to be merged to master! it is strictly for testing purposes.
the commit addes a new dummy_label to deploy/Dockerfile.
after the docker image is built, type `docker inspect <image_tag>` to verify the new label.