### PR TITLE
Yogev/enhance luks configuration

### DIFF
--- a/deploy/helm/lb-csi/templates/lb-csi-node.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-node.yaml
@@ -65,6 +65,10 @@ spec:
               value: text
             - name: LB_CSI_LOG_TIME
               value: "true"
+{{- if .Values.luksConfigDir }}
+            - name: LB_CSI_LUKS_CONFIG_PATH
+              value: {{ .Values.luksConfigDir | quote }}
+{{- end }}
           imagePullPolicy: "Always"
           securityContext:
             privileged: true
@@ -84,6 +88,10 @@ spec:
 {{- range .Values.jwtSecret }}
             - name: {{ .name }}
               mountPath: "/etc/lb-csi"
+{{- end }}
+{{- if .Values.luksConfigDir }}
+            - name: luks-config-dir
+              mountPath: {{ .Values.luksConfigDir | quote }}
 {{- end }}
         - name: csi-node-driver-registrar
           image: {{ .Values.sidecarImageRegistry }}/sig-storage/csi-node-driver-registrar:v2.1.0
@@ -169,6 +177,12 @@ spec:
           - key: jwt
             path: jwt
             mode: 0777
+{{- end }}
+{{- if .Values.luksConfigDir }}
+      - name: luks-config-dir
+        hostPath:
+          path: {{ .Values.luksConfigDir | quote }}
+          type: DirectoryOrCreate
 {{- end }}
 {{- if empty .Values.imagePullSecrets | not }}
       imagePullSecrets:

--- a/deploy/helm/lb-csi/values.schema.json
+++ b/deploy/helm/lb-csi/values.schema.json
@@ -63,6 +63,10 @@
     "jwtSecret": {
       "description": "LightOS API JWT to mount as volume for controller and node pods.",
       "type": "array"
+    },
+    "luksConfigDir": {
+      "description": "Path to host folder that will be mounted to plugin for reading luks_config.yaml",
+      "type": "string"
     }
   },
   "required": [

--- a/deploy/helm/lb-csi/values.yaml
+++ b/deploy/helm/lb-csi/values.yaml
@@ -12,6 +12,7 @@ discoveryClientImage: "lb-nvme-discovery-client:1.9.1"
 controllerServiceAccountName: lb-csi-ctrl-sa
 nodeServiceAccountName: lb-csi-node-sa
 kubeletRootDir: /var/lib/kubelet
+#luksConfigDir: /etc/lb-csi-luks-config
 #registryUsername: ""
 # jwtSecret:
 # - name: cluster-admin-jwt

--- a/main.go
+++ b/main.go
@@ -56,6 +56,12 @@ Supported environment variables:
         the '{{.DefaultBackend}}' backend with default configuration will be used.
         runtime backend configuration changes are not supported, to reload the
         config - restart the plugin. (default: {{.BackendCfgPath}})
+  LB_CSI_LUKS_CONFIG_PATH   - path to LUKS v2 encryption configuration
+        file, in YAML format. This file enables a mechanism to override some config
+        on a per Node basis which gives the freedom to set more loose config then
+        by specifying using deployment config. If specified file does not exist -
+        sane defaults will be used. Runtime configuration changes are not
+        supported, to reload the config - restart the plugin.
 
 Command line flags:
 `
@@ -73,6 +79,7 @@ var defaults = driver.Config{
 	DefaultBackend: "dsc",
 	BackendCfgPath: filepath.Join(defaultCfgDirPath, defaultBackendCfgFileName),
 	JWTPath:        filepath.Join(defaultCfgDirPath, defaultJWTFileName),
+	LUKSCfgPath:    filepath.Join(defaultCfgDirPath, driver.DefaultLUKSCfgFileName),
 
 	NodeID:   "",
 	Endpoint: "unix:///tmp/csi.sock",
@@ -110,6 +117,8 @@ var (
 		"Path to global LightOS API auth JWT, see $LB_CSI_JWT_PATH.")
 	backendCfgPath = flag.StringP("be-cfg-path", "b", "",
 		"Backend config path, see $LB_CSI_BE_CONFIG_PATH.")
+	luksCfgPath = flag.StringP("luks-cfg-path", "L", "",
+		"LUKS config path, see $LB_CSI_LUKS_CONFIG_PATH.")
 	version = flag.Bool("version", false, "Print the version and exit.")
 	help    = flag.BoolP("help", "h", false, "Print help and exit.")
 
@@ -199,6 +208,8 @@ func main() {
 		DefaultBackend: defaults.DefaultBackend, // not user configurable.
 		BackendCfgPath: pickStr(*backendCfgPath, "LB_CSI_BE_CONFIG_PATH",
 			defaults.BackendCfgPath),
+		LUKSCfgPath: pickStr(*luksCfgPath, "LB_CSI_LUKS_CONFIG_PATH",
+			defaults.LUKSCfgPath),
 		JWTPath:       pickStr(*jwtPath, "LB_CSI_JWT_PATH", defaults.JWTPath),
 		NodeID:        pickStr(*nodeID, "LB_CSI_NODE_ID", defaults.NodeID),
 		Endpoint:      pickStr(*endpoint, "CSI_ENDPOINT", defaults.Endpoint),

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	neturl "net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -77,6 +78,7 @@ type Config struct {
 	DefaultBackend string
 	BackendCfgPath string // if valid - contents override DefaultBackend.
 	JWTPath        string
+	LUKSCfgPath    string
 
 	NodeID   string
 	Endpoint string // must be a Unix Domain Socket URI
@@ -96,11 +98,12 @@ type Config struct {
 }
 
 type Driver struct {
-	sockPath  string // control UDS path.
-	jwtPath   string // LightOS API authN/authZ JWT.
-	nodeID    string
-	hostNQN   string
-	defaultFS string
+	sockPath    string // control UDS path.
+	jwtPath     string // LightOS API authN/authZ JWT.
+	luksCfgFile string // path to luks configuration yaml file.
+	nodeID      string
+	hostNQN     string
+	defaultFS   string
 
 	srv *grpc.Server
 	log *logrus.Entry
@@ -215,6 +218,7 @@ func New(cfg Config) (*Driver, error) { //nolint:gocritic
 		nodeID:        cfg.NodeID,
 		transport:     cfg.Transport,
 		squelchPanics: cfg.SquelchPanics,
+		luksCfgFile:   filepath.Join(cfg.LUKSCfgPath, DefaultLUKSCfgFileName),
 	}
 
 	if err := checkNodeID(cfg.NodeID); err != nil {


### PR DESCRIPTION
Enable configuration injection on the node level for client side encryption feature.

Added a single parameter for the luksFormat api, but additional parameters can use this mechanism in future as needed.

the parameter supported is limiting ram usage in luks format api, as suggested here:
https://github.com/LightBitsLabs/los-csi/pull/22 