### PR TITLE
busybox modprobe lacks zstd support, fix this

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -31,6 +31,7 @@ RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/m
     xfsprogs-extra=5.12.0-r0 \
     lsblk \
     blkid \
+    kmod \
     $EXTRA_PACKAGES
 
 COPY licenses /licenses


### PR DESCRIPTION
Newer Ubuntu Kernels built their kernel modules compressed with zstd, this actually prevents the csi driver to load the required kernel module:

```bash
2024-01-09T16:56:14.359520701+01:00 stdout F filename:       /lib/modules/6.6.10-060610-generic/kernel/drivers/nvme/host/nvme-tcp.ko.zst
2024-01-09T16:56:14.366091503+01:00 stderr F modprobe: can't load module nvme_tcp (kernel/drivers/nvme/host/nvme-tcp.ko.zst): invalid module format
```
This is because `modprobe` is `busybox`.

With this PR `kmod` is installed which depends on zstd-libs and provides zstd support.