### PR TITLE
syscall.Statfs instead of unix.Statfs to be arch independent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0
@@ -31,6 +30,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -14,12 +14,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	guuid "github.com/google/uuid"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	mountutils "k8s.io/mount-utils"
@@ -791,13 +791,12 @@ func filesystemNodeGetVolumeStats(volPath string) (*csi.NodeGetVolumeStatsRespon
 		return nil, mkEnoent("no volume is mounted on %s '%s'", volPathField, volPath)
 	}
 
-	statfs := &unix.Statfs_t{}
-	err = unix.Statfs(volPath, statfs)
+	statfs := &syscall.Statfs_t{}
+	err = syscall.Statfs(volPath, statfs)
 	if err != nil {
 		return nil, mkExternal("failed to collect FS info for mount '%s': %s", volPath, err)
 	}
 
-	//nolint:unconvert // unix.Statfs_t fields have diff sizes on diff architectures.
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
 			{


### PR DESCRIPTION
This removes a small glitch and linter would also complain.

syscall.Statfs takes the arch specific values, whereas unix.Statfs only works on linux.
