### PR TITLE
Update to go-1.22 and alpine-3.19

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.17.2-alpine3.14 AS builder
+FROM golang:1.22-alpine3.19 AS builder
 
 RUN apk update && \
     apk add --no-cache \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 # update alpine to get cryptsetup 2.4.x
-FROM alpine:3.16
+FROM alpine:3.19
 
 LABEL org.opencontainers.image.title="Lightbits CSI Plugin" \
     org.opencontainers.image.description="CSI plugin for Lightbits Cluster" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightbitslabs/los-csi
 
-go 1.17
+go 1.22
 
 require (
 	github.com/container-storage-interface/spec v1.3.0

--- a/pkg/driver/backend/dsc/discovery_client.go
+++ b/pkg/driver/backend/dsc/discovery_client.go
@@ -6,7 +6,6 @@ package dsc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -97,7 +96,7 @@ func (be *Backend) checkDSCCfgPath() error {
 func (be *Backend) writeDSCCfgFile(finalPath string, tgtEnv *backend.TargetEnv) error {
 	transport := "tcp" // currently only NVMe/TCP is supported by the DSC BE
 
-	f, err := ioutil.TempFile(be.dscCfgPath, dscReservedPrefix)
+	f, err := os.CreateTemp(be.dscCfgPath, dscReservedPrefix)
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %s", err)
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -6,7 +6,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	neturl "net/url"
 	"os"
@@ -202,15 +201,15 @@ func createBackend(
 	log *logrus.Entry, hostNQN, cfgPath, defaultBackend string,
 ) (backend.Backend, error) {
 	beType := defaultBackend
-	rawCfg, err := ioutil.ReadFile(cfgPath)
+	rawCfg, err := os.ReadFile(cfgPath)
 	if err == nil {
 		beType, err = backend.DetectType(rawCfg)
 		if err != nil {
-			return nil, fmt.Errorf("bad backend config file '%s': %s", cfgPath, err)
+			return nil, fmt.Errorf("bad backend config file '%s': %w", cfgPath, err)
 		}
 	} else {
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to read backend config: %s", err)
+			return nil, fmt.Errorf("failed to read backend config: %w", err)
 		}
 		log.Infof("missing backend config file '%s', falling back to default backend '%s'",
 			cfgPath, defaultBackend)
@@ -382,7 +381,7 @@ func (d *Driver) Run() error {
 
 func (d *Driver) setJWT(jwtPath string) {
 	log := d.log.WithField("jwt-path", jwtPath)
-	b, err := ioutil.ReadFile(jwtPath)
+	b, err := os.ReadFile(jwtPath)
 	if err != nil {
 		log.WithError(err).Warn("failed to load global JWT, clearing it")
 		d.jwt = ""

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -205,11 +205,11 @@ func createBackend(
 	if err == nil {
 		beType, err = backend.DetectType(rawCfg)
 		if err != nil {
-			return nil, fmt.Errorf("bad backend config file '%s': %w", cfgPath, err)
+			return nil, fmt.Errorf("bad backend config file '%s': %s", cfgPath, err)
 		}
 	} else {
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("failed to read backend config: %w", err)
+			return nil, fmt.Errorf("failed to read backend config: %s", err)
 		}
 		log.Infof("missing backend config file '%s', falling back to default backend '%s'",
 			cfgPath, defaultBackend)

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -104,7 +103,7 @@ func queryLBforTargetEnv(
 }
 
 func (d *Driver) getDeviceUUID(device string) (string, error) {
-	devUUID, err := ioutil.ReadFile(filepath.Join("/sys/block", device, "wwid"))
+	devUUID, err := os.ReadFile(filepath.Join("/sys/block", device, "wwid"))
 	if err != nil {
 		d.log.Debugf("failed to read wwid from dev: %s err: %s", device, err)
 		return "", err

--- a/pkg/lb/lbgrpc/client_test.go
+++ b/pkg/lb/lbgrpc/client_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"os"
@@ -135,7 +135,7 @@ func TestMain(m *testing.M) {
 			"to the cluster mgmt endpoint must be specified")
 	}
 	if logPath == "" {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 		log.SetLevel(logrus.PanicLevel)
 	} else {
 		log.SetFormatter(&logrus.TextFormatter{
@@ -200,22 +200,23 @@ func chkZeroFields(s interface{}) {
 // the test with a corresponding error message.
 //
 // the expected JSON file format, by example, is:
-//   {
-//     "UUID": "864eb8af-f055-4c41-b8a3-e9a527483db3",
-//     "SubNQN": "nqn.2014-08.org.nvmexpress:NVMf:uuid:c3dc6852-adcf-46f0-bc7b-a2d687ecee3a",
-//     "Nodes": [
-//       {
-//         "Name": "lb-node-00",
-//         "Hostname": "lb-node-00",
-//         "UUID": "3f5e5352-3e29-4cea-984d-dbbe768a9476",
-//         "MgmtEP": "172.18.0.7:80",
-//         "DataEP": "172.18.0.7:4420"
-//       },
-//           ...
-//     ]
-//   }
+//
+//	{
+//	  "UUID": "864eb8af-f055-4c41-b8a3-e9a527483db3",
+//	  "SubNQN": "nqn.2014-08.org.nvmexpress:NVMf:uuid:c3dc6852-adcf-46f0-bc7b-a2d687ecee3a",
+//	  "Nodes": [
+//	    {
+//	      "Name": "lb-node-00",
+//	      "Hostname": "lb-node-00",
+//	      "UUID": "3f5e5352-3e29-4cea-984d-dbbe768a9476",
+//	      "MgmtEP": "172.18.0.7:80",
+//	      "DataEP": "172.18.0.7:4420"
+//	    },
+//	        ...
+//	  ]
+//	}
 func parseClusterInfo(path string) *clusterInfo {
-	cij, err := ioutil.ReadFile(path)
+	cij, err := os.ReadFile(path)
 	if err != nil {
 		flagDie("invalid cluster info file path '%s' specified: %s", path, err)
 	}
@@ -239,7 +240,7 @@ func parseClusterInfo(path string) *clusterInfo {
 }
 
 func loadJwt(path string) string {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		flagDie("invalid JWT file path '%s' specified: %s", path, err)
 	}


### PR DESCRIPTION
Hi,

according to: https://go.dev/doc/devel/release, only go 1.20, 1.21 and 1.22 are supported anymore and get security and bug fixes.

alpine 3.16 also nears its end of life: https://endoflife.date/alpine

Update the build to use go-1.22 and Alpine 3.19, also replace all occurrences of `io/ioutil` which is deprecated since go-1.16 with their supported counterparts.

So if you find these enhancements useful, i would appreciate this, because we get challenged on a regular basis for CVEs in the software we deploy to the clusters of our customers.