### PR TITLE
Chart.yaml add missing app version

### DIFF
--- a/deploy/helm/lb-csi/Chart.yaml
+++ b/deploy/helm/lb-csi/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: lb-csi-plugin
 version: 0.14.0
 description: Helm Chart for Lightbits CSI Plugin.
+appVersion: 1.16.0
 home: https://github.com/lightbitslabs/los-csi
 icon: https://www.lightbitslabs.com/wp-content/uploads/2018/08/cropped-header-logo-32x32.png
 maintainers:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `appVersion` field in the Helm chart for the Lightbits CSI Plugin, providing clearer version information (1.16.0) for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->