### PR TITLE
Add toleration to CSI controller and node pods so that these could be deployed to K8 tainted nodes.  

### DIFF
--- a/deploy/helm/lb-csi/templates/lb-csi-controller.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-controller.yaml
@@ -135,3 +135,11 @@ spec:
       #imagePullSecrets:
       #- name: my-docker-registry-credentials-secret
 {{- end }}
+
+{{- if .Values.lbControllerTolerations }}
+      tolerations:
+       - key: {{ .Values.lbControllerTolerations.key}}
+         operator: {{ .Values.lbControllerTolerations.operator}}
+         value: {{ .Values.lbControllerTolerations.value}}
+         effect: {{ .Values.lbControllerTolerations.effect}}
+{{- end }}

--- a/deploy/helm/lb-csi/templates/lb-csi-node.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-node.yaml
@@ -201,3 +201,11 @@ spec:
       #imagePullSecrets:
       #- name: my-docker-registry-credentials-secret
 {{- end }}
+
+{{- if .Values.lbNodeTolerations }}
+      tolerations:
+       - key: {{ .Values.lbNodeTolerations.key}}
+         operator: {{ .Values.lbNodeTolerations.operator}}
+         value: {{ .Values.lbNodeTolerations.value}}
+         effect: {{ .Values.lbNodeTolerations.effect}}
+{{- end }}

--- a/deploy/helm/lb-csi/values.yaml
+++ b/deploy/helm/lb-csi/values.yaml
@@ -19,3 +19,19 @@ rwx: false
 # - name: cluster-admin-jwt
 #   jwt: |-
 #     ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNkluTjVjM1JsYlRweWIyOTBJaXdpZEhsd0lqb2lTbGRVSW4wLmV5SmhkV1FpT2lKTWFXZG9kRTlUSWl3aVpYaHdJam94TmpRNU9UUXpNelkyTENKcFlYUWlPakUyTVRnME1EY3pOallzSW1semN5STZJbk41YzNSbGMzUnpJaXdpYW5ScElqb2lRMUJzTXpCdVNtVlFXV3hCU1dsRGJtMWpYMlJ2UVNJc0ltNWlaaUk2TVRZeE9EUXdOek0yTml3aWNtOXNaWE1pT2xzaWMzbHpkR1Z0T21Oc2RYTjBaWEl0WVdSdGFXNGlYU3dpYzNWaUlqb2liR2xuYUhSdmN5MWpiR2xsYm5RaWZRLm5PY2pTaTJlMUZ1RFhEMHRsYXFackZnQ2I2WFRqc19Lc2phUHRZbHBUMDZCNmQ5bmhfM1hIejNCRTZIUGJydVM3RERIT2xFOWZNUWpSbUl0LWZDZjJMQ0Jja1J6bm1fQnVGLU9wWGRQc2hDY1plX3VCeUFaTXNkMDJsR05fWHR2Sy03SXh3ZTZsSkd1S215dFdwWUhvcTczUVVfYUhITjItMHJJUFlWSEpfQmN4NDcxblQyRmQzbG5PSFNtNWVZWUhQTzJrcGdUSy0yMkVIX21FUWYxbldjQms3UU15T3RWbVloUmNwN0F3REhDLTllQkNnM0w2VDFFdlV1YWRMTXZpbXNGV2VWeXZya1ZVVzhrWjhZeDJTNlMzMG5FeFN2NHJ3aHVUX3Q4VnNyRFhnUWdWd0ZacGhiZ0dTZTBDQlR1dUNiMkt5TlRvVmxnQjBoQ05mUjBaZw==
+
+# CSI controller pod tolerations will enable controller-pod deployment to the desired node. 
+# Replace values with desired key-value pairs of tainted nodes.  
+lbControllerTolerations:
+  key: "lb-csi-controller"
+  operator: "Equal"
+  value: "lb-csi-controller-pod"
+  effect: "NoSchedule" 
+
+# CSI node pod tolerations will enable node-pod deployment to the desired node. 
+# Replace values with desired key-value pairs of tainted nodes.  
+lbNodeTolerations:
+  key: "lb-csi-controller"
+  operator: "Equal"
+  value: "lb-csi-controller-pod"
+  effect: "NoSchedule" 


### PR DESCRIPTION
In real production environment, it is very likely that K8 nodes are grouped  for certain workload, such as high compute or high IO intensive workload, these nodes are tainted to repel pods that are not ideal for those K8 nodes. 
Tainted Nodes accept pods that has the toleration for those nodes. 

This change will add  toleration to CSI pods for deployment to the desired set of nodes.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configurable tolerations for the CSI controller and node pods, enhancing deployment flexibility in Kubernetes environments.
	- Introduced new options in the Helm chart's configuration for specifying tolerations to manage pod scheduling effectively.

- **Documentation**
	- Updated `values.yaml` to include new sections for `lbControllerTolerations` and `lbNodeTolerations`, providing users with the ability to customize pod scheduling behavior based on node taints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->