### PR TITLE
Replace logrus with slog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/kubernetes-csi/csi-test/v3 v3.1.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sys v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -170,7 +168,6 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
 golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/main.go
+++ b/main.go
@@ -89,7 +89,6 @@ var defaults = driver.Config{
 	LogLevel:      "info",
 	LogRole:       "node",
 	LogTimestamps: false,
-	LogFormat:     "json",
 
 	// hidden, dev-only options:
 	BinaryName:    "lb-csi-plugin",
@@ -113,8 +112,6 @@ var (
 		"Add timestamps to log entries, see $LB_CSI_LOG_TIME.")
 	rwx = flag.BoolP("rwx", "X", false,
 		"Should we expose volumes as ReadWriteMany, see $LB_CSI_RWX.")
-	logFormat = flag.StringP("log-fmt", "f", "",
-		"Log entry format, see $LB_CSI_LOG_FMT.")
 	jwtPath = flag.StringP("jwt-path", "j", "",
 		"Path to global LightOS API auth JWT, see $LB_CSI_JWT_PATH.")
 	backendCfgPath = flag.StringP("be-cfg-path", "b", "",
@@ -232,7 +229,6 @@ func main() {
 		DefaultFS:     pickStr(*defaultFS, "LB_CSI_DEFAULT_FS", defaults.DefaultFS),
 		LogLevel:      pickStr(*logLevel, "LB_CSI_LOG_LEVEL", defaults.LogLevel),
 		LogRole:       pickStr(*logRole, "LB_CSI_LOG_ROLE", defaults.LogRole),
-		LogFormat:     pickStr(*logFormat, "LB_CSI_LOG_FMT", defaults.LogFormat),
 		LogTimestamps: *logTimestamps,
 		Transport:     *transport,
 		SquelchPanics: *squelchPanics,

--- a/pkg/driver/backend/registry.go
+++ b/pkg/driver/backend/registry.go
@@ -2,12 +2,11 @@ package backend
 
 import (
 	"fmt"
+	"log/slog"
 	"regexp"
-
-	"github.com/sirupsen/logrus"
 )
 
-type MakerFn func(log *logrus.Entry, hostNQN string, rawCfg []byte) (Backend, error)
+type MakerFn func(log *slog.Logger, hostNQN string, rawCfg []byte) (Backend, error)
 
 type regEntry struct {
 	beType string
@@ -45,7 +44,7 @@ func RegisterBackend(beType string, maker MakerFn) {
 	beRegistry[beType] = regEntry{beType, maker}
 }
 
-func Make(beType string, log *logrus.Entry, hostNQN string, rawCfg []byte) (Backend, error) {
+func Make(beType string, log *slog.Logger, hostNQN string, rawCfg []byte) (Backend, error) {
 	if re, ok := beRegistry[beType]; ok {
 		return NewWrapper(beType, re.maker, log, hostNQN, rawCfg)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -161,7 +161,6 @@ func getDriver(
 		LogLevel:      "info",
 		LogRole:       "node",
 		LogTimestamps: false,
-		LogFormat:     "json",
 
 		// hidden, dev-only options:
 		BinaryName:    "lb-csi-plugin",

--- a/pkg/driver/csi_md.go
+++ b/pkg/driver/csi_md.go
@@ -94,22 +94,27 @@ func checkProjectName(field, proj string) error {
 //
 // `parameters` as passed to CreateVolume() is a string-to-string (!) KV map
 // that must include:
-//     mgmt-endpoint: <host>:<port>[,<host>:port>...]
-//     mgmt-scheme: "grpcs"
-//     project-name: <project-name>
-//     replica-count: <num-replicas>
+//
+//	mgmt-endpoint: <host>:<port>[,<host>:port>...]
+//	mgmt-scheme: "grpcs"
+//	project-name: <project-name>
+//	replica-count: <num-replicas>
+//
 // may optionally include (if omitted - the default is "disabled"):
-//     compression: <"enabled"|"disabled">
-//     qos-policy-name: <qos-policy-name>
-//     host-encryption: <"enabled"|"disabled">
+//
+//	compression: <"enabled"|"disabled">
+//	qos-policy-name: <qos-policy-name>
+//	host-encryption: <"enabled"|"disabled">
+//
 // e.g.:
-//     mgmt-endpoint: 10.0.0.100:80,10.0.0.101:80
-//     mgmt-scheme: grpcs
-//     project-name: proj-3
-//     replica-count: 2
-//     compression: enabled
-//     qos-policy-name: "io-limited-policy"
-//     host-encryption: enabled
+//
+//	mgmt-endpoint: 10.0.0.100:80,10.0.0.101:80
+//	mgmt-scheme: grpcs
+//	project-name: proj-3
+//	replica-count: 2
+//	compression: enabled
+//	qos-policy-name: "io-limited-policy"
+//	host-encryption: enabled
 type lbCreateVolumeParams struct {
 	mgmtEPs       endpoint.Slice // LightOS mgmt API server endpoints.
 	replicaCount  uint32         // total number of volume replicas.
@@ -239,32 +244,37 @@ func init() {
 //
 // for transmission on the wire, it's serialised into a string with the
 // following fixed format:
-//   mgmt:<host>:<port>[,<host>:<port>...]|nguid:<nguid>[|proj:<proj>][|scheme:<scheme>][|hostcrypto:<format>]
+//
+//	mgmt:<host>:<port>[,<host>:<port>...]|nguid:<nguid>[|proj:<proj>][|scheme:<scheme>][|hostcrypto:<format>]
+//
 // where:
-//    <host>    - mgmt API server endpoint of the LightOS cluster hosting the
-//            volume. can be a hostname or an IP address. more than one
-//            comma-separated <host>:<port> pair can be specified.
-//            TODO: IPv6 support will require amending parsing for bizarre
-//            extra allowed characters.
-//    <port>    - variable-length printable decimal representation of the
-//            uint16 port number, no leading zeroes.
-//    <nguid>   - volume NGUID (see NVMe spec, Identify NS Data Structure)
-//            in its "canonical", 36-character long, RFC-4122 compliant string
-//            representation.
-//    <proj>    - project/tenant name on the LB cluster. this field is
-//            temporarily optional in resource IDs for reverse compatibility,
-//            though modern LB clusters will refuse requests without it.
-//            see notes below in parseCSIResourceID().
-//    <scheme>  - transport scheme for communicating with the LB cluster.
-//            the only valid value is currently 'grpcs' (gRPC over TLS), and
-//            scheme is temporarily optional, in which case it defaults to...
-//            'grpcs'! modern LB clusters will refuse plain unencrypted gRPC
-//            requests anyway. see below in parseCSIResourceID().
-//    <hostcrypto>  - specifies the crypto format of the hostEncrypted volume, only luks2 is possible.
-//            this is optional and will only exist for host-encrypted volumes.
+//
+//	<host>    - mgmt API server endpoint of the LightOS cluster hosting the
+//	        volume. can be a hostname or an IP address. more than one
+//	        comma-separated <host>:<port> pair can be specified.
+//	        TODO: IPv6 support will require amending parsing for bizarre
+//	        extra allowed characters.
+//	<port>    - variable-length printable decimal representation of the
+//	        uint16 port number, no leading zeroes.
+//	<nguid>   - volume NGUID (see NVMe spec, Identify NS Data Structure)
+//	        in its "canonical", 36-character long, RFC-4122 compliant string
+//	        representation.
+//	<proj>    - project/tenant name on the LB cluster. this field is
+//	        temporarily optional in resource IDs for reverse compatibility,
+//	        though modern LB clusters will refuse requests without it.
+//	        see notes below in parseCSIResourceID().
+//	<scheme>  - transport scheme for communicating with the LB cluster.
+//	        the only valid value is currently 'grpcs' (gRPC over TLS), and
+//	        scheme is temporarily optional, in which case it defaults to...
+//	        'grpcs'! modern LB clusters will refuse plain unencrypted gRPC
+//	        requests anyway. see below in parseCSIResourceID().
+//	<hostcrypto>  - specifies the crypto format of the hostEncrypted volume, only luks2 is possible.
+//	        this is optional and will only exist for host-encrypted volumes.
+//
 // e.g.:
-//   mgmt:10.0.0.1:80,10.0.0.2:80|nguid:6bb32fb5-99aa-4a4c-a4e7-30b7787bbd66|proj:a|scheme:grpcs
-//   mgmt:lb01.net:80|nguid:6bb32fb5-99aa-4a4c-a4e7-30b7787bbd66|proj:b|scheme:grpcs|hostcrypto:luks2
+//
+//	mgmt:10.0.0.1:80,10.0.0.2:80|nguid:6bb32fb5-99aa-4a4c-a4e7-30b7787bbd66|proj:a|scheme:grpcs
+//	mgmt:lb01.net:80|nguid:6bb32fb5-99aa-4a4c-a4e7-30b7787bbd66|proj:b|scheme:grpcs|hostcrypto:luks2
 //
 // TODO: the CSI spec mandates that strings "SHALL NOT" exceed 128 bytes.
 // K8s is more lenient (at least 253 bytes, likely more). in any case, with
@@ -387,7 +397,7 @@ func (d *Driver) supportedAccessModes(isBlockVolumeMode bool) []csi.VolumeCapabi
 		supportedAccessModes = append(supportedAccessModes,
 			csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER)
 	}
-	d.log.Infof("RWX is %t returning access-modes: %+v", d.rwx, supportedAccessModes)
+	d.log.Info("returning access-modes", "requested", d.rwx, "supported", supportedAccessModes)
 	return supportedAccessModes
 }
 

--- a/pkg/driver/status.go
+++ b/pkg/driver/status.go
@@ -5,8 +5,8 @@ package driver
 
 import (
 	"fmt"
+	"log/slog"
 
-	"github.com/sirupsen/logrus"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,10 +37,10 @@ func shouldRetryOn(err error) bool {
 }
 
 func mungeLBErr(
-	log *logrus.Entry, err error, format string, args ...interface{},
+	log *slog.Logger, err error, format string, args ...interface{},
 ) error {
 	if shouldRetryOn(err) {
-		log.Warnf(format+": "+err.Error(), args...)
+		log.Warn(format+": "+err.Error(), args...)
 		return mkEagain("temporarily "+format, args...)
 	}
 	return mkExternal(format+": "+err.Error(), args...)

--- a/pkg/grpcutil/grpcutil.go
+++ b/pkg/grpcutil/grpcutil.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,60 +29,6 @@ func RespDetailInterceptor(
 		}
 	}
 	return resp, err
-}
-
-func LBCodeToLogrusLevel(code codes.Code) logrus.Level {
-	switch code {
-	case codes.OK,
-		codes.Canceled,
-		codes.DeadlineExceeded,
-		codes.NotFound,
-		codes.Unavailable:
-		return logrus.InfoLevel
-	case codes.Aborted,
-		codes.AlreadyExists,
-		codes.FailedPrecondition,
-		codes.InvalidArgument,
-		codes.OutOfRange,
-		codes.PermissionDenied,
-		codes.ResourceExhausted,
-		codes.Unauthenticated:
-		return logrus.WarnLevel
-	case codes.DataLoss,
-		codes.Internal,
-		codes.Unimplemented,
-		codes.Unknown:
-		return logrus.ErrorLevel
-	default:
-		return logrus.ErrorLevel
-	}
-}
-
-func CodeToLogrusLevel(code codes.Code) logrus.Level {
-	switch code {
-	case codes.OK,
-		codes.Canceled:
-		return logrus.InfoLevel
-	case codes.Aborted,
-		codes.AlreadyExists,
-		codes.DeadlineExceeded,
-		codes.FailedPrecondition,
-		codes.InvalidArgument,
-		codes.NotFound,
-		codes.OutOfRange,
-		codes.PermissionDenied,
-		codes.ResourceExhausted,
-		codes.Unauthenticated,
-		codes.Unavailable,
-		codes.Unimplemented:
-		return logrus.WarnLevel
-	case codes.DataLoss,
-		codes.Internal,
-		codes.Unknown:
-		return logrus.ErrorLevel
-	default:
-		return logrus.ErrorLevel
-	}
 }
 
 func ErrFromCtxErr(err error) error {

--- a/pkg/lb/lbgrpc/client.go
+++ b/pkg/lb/lbgrpc/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -15,8 +16,6 @@ import (
 
 	guuid "github.com/google/uuid"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
@@ -100,7 +99,7 @@ type lbResolver struct {
 	// (or, equivalently, per-LightOS cluster) thing, an artefact of how
 	// the dialling gRPC machinery be looking up the resolver later.
 	scheme string
-	log    *logrus.Entry
+	log    *slog.Logger
 
 	cc resolver.ClientConn
 
@@ -112,17 +111,14 @@ type lbResolver struct {
 
 }
 
-func newLbResolver(log *logrus.Entry, scheme string, targets endpoint.Slice) *lbResolver {
-	log = log.WithField("lb-resolver", scheme)
+func newLbResolver(log *slog.Logger, scheme string, targets endpoint.Slice) *lbResolver {
 	r := &lbResolver{
 		scheme: scheme,
 		eps:    targets.Clone(),
-		log:    log,
+		log:    log.With("lb-resolver", scheme),
 		tgts:   targets.String(),
 	}
-	log.WithFields(logrus.Fields{
-		"targets": r.tgts,
-	}).Info("initialising...")
+	log.Info("initialising...", "targets", r.tgts)
 	return r
 }
 
@@ -150,9 +146,7 @@ func (r *lbResolver) Build(
 	_ resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions,
 ) (resolver.Resolver, error) {
 	r.cc = cc
-	r.log.WithFields(logrus.Fields{
-		"targets": r.tgts,
-	}).Info("building...")
+	r.log.Info("building...", "targets", r.tgts)
 	r.updateCCState()
 	return r, nil
 }
@@ -174,9 +168,7 @@ func (r *lbResolver) ResolveNow(_ resolver.ResolveNowOptions) {
 	}
 	r.tgts = r.eps.String()
 	r.mu.Unlock()
-	r.log.WithFields(logrus.Fields{
-		"targets": r.tgts,
-	}).Info("resolving...")
+	r.log.Info("resolving...", "targets", r.tgts)
 	r.updateCCState()
 }
 
@@ -193,7 +185,7 @@ type Client struct {
 
 	id   string
 	tgts string // cached string repr of `eps`
-	log  *logrus.Entry
+	log  *slog.Logger
 
 	// peerMu protects all peer-related fields:
 	peerMu   sync.Mutex
@@ -215,14 +207,14 @@ type Client struct {
 // passed here) - `DeadlineExceeded` will be returned as usual, and the caller
 // can retry the operation.
 func Dial(
-	ctx context.Context, log *logrus.Entry, targets endpoint.Slice, mgmtScheme string,
+	ctx context.Context, log *slog.Logger, targets endpoint.Slice, mgmtScheme string,
 ) (*Client, error) {
 	if !targets.IsValid() {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"invalid target endpoints specified: [%s]", targets)
 	}
 	id := fmt.Sprintf("%07s", strconv.FormatUint(uint64(prng.Uint32()), 36))
-	log = log.WithField("clnt-id", id)
+	log = log.With("clnt-id", id)
 
 	res := &Client{
 		eps:  targets.Clone(),
@@ -231,21 +223,11 @@ func Dial(
 		log:  log,
 	}
 
-	logger := log.WithFields(logrus.Fields{
-		"clnt-type": "lbgrpc",
-		"targets":   res.tgts,
-	})
-	logger.Info("connecting...")
+	log.Info("connecting...", "targets", res.tgts, "clnt-type", "lbgrpc")
 
-	logrusOpts := []grpc_logrus.Option{
-		grpc_logrus.WithLevels(grpcutil.LBCodeToLogrusLevel),
-	}
 	interceptors := []grpc.UnaryClientInterceptor{
 		mkUnaryClientInterceptor(res),
-		grpc_logrus.UnaryClientInterceptor(log, logrusOpts...),
-		grpc_logrus.PayloadUnaryClientInterceptor(log,
-			func(context.Context, string) bool { return true },
-		),
+		// TODO add slog interceptors
 	}
 
 	// these are broadly in line with the expected server SLOs:
@@ -288,10 +270,10 @@ func Dial(
 	}
 
 	if mgmtScheme == "grpc" {
-		logger.Infof("connecting insecurely")
+		log.Info("connecting insecurely")
 		opts = append(opts, grpc.WithInsecure())
 	} else if mgmtScheme == "grpcs" {
-		logger.Infof("connecting securely")
+		log.Info("connecting securely")
 		opts = append(opts, grpc.WithTransportCredentials(
 			// TODO: one of those days, we'll add the ability to specify
 			// certs to trust on a given deployment. until then:
@@ -306,13 +288,13 @@ func Dial(
 		opts...,
 	)
 	if err != nil {
-		logger.WithField("error", err.Error()).Warn("failed to connect")
+		log.With("error", err.Error()).Warn("failed to connect")
 		return nil, err
 	}
 
 	res.clnt = mgmt.NewDurosAPIClient(res.conn)
 
-	logger.Info("connected!")
+	log.Info("connected!")
 	return res, nil
 }
 
@@ -350,10 +332,10 @@ func (c *Client) peerReviewUnaryInterceptor( // sic!
 		}
 		// don't want to warn on healthy flow...
 		if c.switched {
-			c.log.Warnf("switched target: %s -> %s", last, curr)
+			c.log.Warn("switched target", "last", last, "current", curr)
 		} else {
 			c.switched = true
-			c.log.Infof("switched target: %s -> %s", last, curr)
+			c.log.Info("switched target", "last", last, "current", curr)
 		}
 	} else {
 		c.peerMu.Unlock()
@@ -363,7 +345,7 @@ func (c *Client) peerReviewUnaryInterceptor( // sic!
 
 func (c *Client) Close() {
 	c.conn.Close() //revive:disable-line:unhandled-error // nothing to do about it.
-	c.log.WithField("targets", c.Targets()).Info("disconnected!")
+	c.log.With("targets", c.Targets()).Info("disconnected!")
 }
 
 func (c *Client) Targets() string {
@@ -484,10 +466,10 @@ func (c *Client) lbNodeFromGRPC(node *mgmt.DurosNodeInfo) (*lb.Node, error) {
 			"got bad node from LB: '%s' has invalid UUID '%s'", node.Name, node.UUID)
 	}
 
-	log := c.log.WithFields(logrus.Fields{
-		"node-name": node.Name,
-		"node-uuid": uuid,
-	})
+	log := c.log.With(
+		"node-name", node.Name,
+		"node-uuid", uuid,
+	)
 
 	dataEP, err := endpoint.Parse(node.NvmeEndpoint)
 	if err != nil {
@@ -498,7 +480,7 @@ func (c *Client) lbNodeFromGRPC(node *mgmt.DurosNodeInfo) (*lb.Node, error) {
 
 	// TODO: make this a full-blown mandatory check?
 	if strings.TrimSpace(node.Hostname) == "" {
-		log.Warnf("LB returned node with empty hostname '%s'", node.Hostname)
+		log.Warn("LB returned node with empty hostname", "hostname", node.Hostname)
 	}
 
 	switch node.State {
@@ -509,7 +491,7 @@ func (c *Client) lbNodeFromGRPC(node *mgmt.DurosNodeInfo) (*lb.Node, error) {
 		mgmt.DurosNodeInfo_Unattached,
 		mgmt.DurosNodeInfo_Attaching,
 		mgmt.DurosNodeInfo_Detaching:
-		log.Warnf("LB returned node in degraded state '%s' (%d)", node.State, node.State)
+		log.Warn("LB returned node in degraded state", "node", node.Name, "state", node.State)
 	default:
 		return nil, status.Errorf(codes.Internal,
 			"got bad node from LB: '%s' has unexpected state '%s' (%d)",
@@ -614,20 +596,14 @@ func (c *Client) lbVolumeFromGRPC(
 		// the only valid states nowadays
 	case mgmt.Volume_Rollback:
 		// TODO: Better handle Rollback state
-		c.log.WithFields(logrus.Fields{
-			"vol-name": vol.Name,
-			"vol-uuid": vol.UUID,
-		}).Warnf("LB returned volume in unsupported state '%s' (%d)", vol.State, vol.State)
+		c.log.Warn("LB returned volume in unsupported state", "vol-name", vol.Name, "vol-uuid", vol.UUID, "state", vol.State)
 		return nil, status.Errorf(codes.Internal,
 			"got bad volume from LB: '%s' has unexpected state '%s' (%d)",
 			vol.Name, vol.State, vol.State)
 	case mgmt.Volume_Deleted:
 		// TODO: remove this case once the LightOS API drops the
 		// deprecated volume states...
-		c.log.WithFields(logrus.Fields{
-			"vol-name": vol.Name,
-			"vol-uuid": vol.UUID,
-		}).Warnf("LB returned volume in deprecated state '%s' (%d)", vol.State, vol.State)
+		c.log.Warn("LB returned volume in deprecated state", "vol-name", vol.Name, "vol-uuid", vol.UUID, "state", vol.State)
 		fallthrough
 	default:
 		return nil, status.Errorf(codes.Internal,
@@ -747,8 +723,7 @@ func (c *Client) CreateVolume(
 	}
 	if snapshotID != guuid.Nil {
 		req.SourceSnapshotUUID = snapshotID.String()
-		c.log.Debugf("creating volume '%s' from source snapshot uuid: %s",
-			req.Name, req.SourceSnapshotUUID)
+		c.log.Debug("creating volume from source snapshot uuid", "volume", req.Name, "uuid", req.SourceSnapshotUUID)
 	}
 	vol, err := c.clnt.CreateVolume(ctx, &req)
 	if err != nil {
@@ -761,10 +736,10 @@ func (c *Client) CreateVolume(
 	}
 	uuid := lbVol.UUID
 
-	log := c.log.WithFields(logrus.Fields{
-		"vol-name": lbVol.Name,
-		"vol-uuid": lbVol.UUID,
-	})
+	log := c.log.With(
+		"vol-name", lbVol.Name,
+		"vol-uuid", lbVol.UUID,
+	)
 
 	if !strlist.AreEqual(lbVol.ACL, acl) {
 		// both ACLs were normalised, so these are no order-related discrepancies:
@@ -776,8 +751,7 @@ func (c *Client) CreateVolume(
 		// currently we don't support target-side-RO volumes, so this is
 		// unexpected. on the other hand - let the caller handle it.
 		if !lbVol.IsWritable() {
-			log.Warnf("LB created volume that is not currently usable: "+
-				"its protection state is '%s'", lbVol.Protection)
+			log.Warn("LB created volume that is not currently usable", "its protection state", lbVol.Protection)
 		}
 	}
 
@@ -787,8 +761,7 @@ func (c *Client) CreateVolume(
 	case lb.VolumeDeleting,
 		lb.VolumeUpdating,
 		lb.VolumeFailed:
-		log.Warnf("LB volume creation returned volume in unexpected state '%s' (%d)",
-			lbVol.State, lbVol.State)
+		log.Warn("LB volume creation returned volume in unexpected state", "state", lbVol.State)
 		return nil, status.Errorf(codes.Internal,
 			"LB created volume '%s' in inappropriate state '%s' (%d)",
 			name, lbVol.State, lbVol.State)
@@ -833,8 +806,7 @@ func (c *Client) CreateVolume(
 
 		if !strlist.AreEqual(orgLbVol.ACL, lbVol.ACL) {
 			// this is likely just a race with some other instance...
-			log.Warnf("got volume with unexpected ACL %#q instead of %#q while "+
-				"waiting for volume to be created", lbVol.ACL, orgLbVol.ACL)
+			log.Warn("got volume with unexpected ACL while waiting for volume to be created", "acl", lbVol.ACL, "expected", orgLbVol.ACL)
 		}
 
 		switch lbVol.State {
@@ -848,8 +820,7 @@ func (c *Client) CreateVolume(
 			return false, status.Errorf(codes.Aborted,
 				"volume appears to have been deleted in parallel")
 		case lb.VolumeFailed:
-			log.Warnf("got bad volume from LB after create: '%s' is in state %s (%d)",
-				name, lbVol.State, lbVol.State)
+			log.Warn("got bad volume from LB after create", "name", name, "state", lbVol.State)
 			// LB failed to create a volume (e.g. too many nodes are
 			// down). try to cause the CO to retry the whole shebang
 			// anew.
@@ -920,10 +891,10 @@ func (c *Client) DeleteVolume(
 			return false, err
 		}
 
-		log := c.log.WithFields(logrus.Fields{
-			"vol-name": lbVol.Name,
-			"vol-uuid": lbVol.UUID,
-		})
+		log := c.log.With(
+			"vol-name", lbVol.Name,
+			"vol-uuid", lbVol.UUID,
+		)
 
 		switch lbVol.State {
 		case lb.VolumeAvailable,
@@ -934,8 +905,7 @@ func (c *Client) DeleteVolume(
 			lb.VolumeUpdating:
 			// this is somewhat unlikely, as the original DeleteVolume()
 			// API call should have failed...
-			log.Warnf("got volume in unexpected state from LB after delete: %s (%d)",
-				lbVol.State, lbVol.State)
+			log.Warn("got volume in unexpected state from LB after delete", "state", lbVol.State)
 			// moreover, this volume is unlikely to transition from
 			// 'Creating' to 'Deleted' on its own. let admins or K8s
 			// sort this out (the latter is likely to retry deleting).
@@ -945,8 +915,7 @@ func (c *Client) DeleteVolume(
 			// also highly unlikely, if it was already 'Failed', the
 			// original DeleteVolume() would have failed too, and a
 			// volume can't just hop into 'Failed' state afterwards.
-			log.Warnf("got volume in unexpected state from LB after delete: %s (%d)",
-				lbVol.State, lbVol.State)
+			log.Warn("got volume in unexpected state from LB after delete", "state", lbVol.State)
 			// still, it's gone, so...
 			fallthrough
 		case lb.VolumeDeleting:
@@ -1008,13 +977,10 @@ func (c *Client) doUpdateVolume(
 	ctx, cancel := cloneCtxWithCap(ctx)
 	defer cancel()
 
-	log := c.log.WithField("vol-uuid", uuid)
+	log := c.log.With("vol-uuid", uuid)
 
 	badError := func(op, prep string, err error) (*lb.Volume, error) {
-		log.WithFields(logrus.Fields{
-			"err-type": fmt.Sprintf("%T", err),
-			"err-msg":  err.Error(),
-		}).Errorf("unexpected error on volume update: failed to %s volume", op)
+		log.Error("unexpected error on volume update", "op", op, "error", err)
 		return nil, status.Errorf(codes.Unknown,
 			"failed to %s volume %s %s LB: %s", op, uuid, prep, err)
 	}
@@ -1037,7 +1003,7 @@ func (c *Client) doUpdateVolume(
 			return badError("get", "from", err)
 		}
 	}
-	log = log.WithField("vol-name", lbVol.Name)
+	log = log.With("vol-name", lbVol.Name)
 
 	switch lbVol.State {
 	case lb.VolumeCreating:
@@ -1069,7 +1035,7 @@ func (c *Client) doUpdateVolume(
 
 	update, err := hook(lbVol)
 	if err != nil {
-		log.Debugf("volume update aborted by hook: %s", err)
+		log.Debug("volume update aborted by hook", "error", err)
 		// propagate the hook error to the caller verbatim so they can
 		// recognise it, if necessary:
 		return nil, err
@@ -1095,14 +1061,14 @@ func (c *Client) doUpdateVolume(
 		required = true
 		acl := strlist.CopyUniqueSorted(update.ACL)
 		req.Acl = &mgmt.StringList{Values: acl}
-		log = log.WithField("acl-src", fmt.Sprintf("%#q", lbVol.ACL))
-		log = log.WithField("acl-tgt", fmt.Sprintf("%#q", acl))
+		log = log.With("acl-src", fmt.Sprintf("%#q", lbVol.ACL))
+		log = log.With("acl-tgt", fmt.Sprintf("%#q", acl))
 	}
 	if update.Capacity != 0 {
 		required = true
 		req.Size = fmt.Sprintf("%d", update.Capacity)
-		log = log.WithField("capacity-src", fmt.Sprintf("%d", lbVol.Capacity))
-		log = log.WithField("capacity-tgt", fmt.Sprintf("%d", update.Capacity))
+		log = log.With("capacity-src", fmt.Sprintf("%d", lbVol.Capacity))
+		log = log.With("capacity-tgt", fmt.Sprintf("%d", update.Capacity))
 	}
 	if !required {
 		// bug, code not updated to match some newly added lb.VolumeUpdate
@@ -1110,7 +1076,7 @@ func (c *Client) doUpdateVolume(
 		log.Warn("volume update requested by hook, but no updates recognised")
 		return lbVol, nil
 	}
-	log = log.WithField("etag", lbVol.ETag)
+	log = log.With("etag", lbVol.ETag)
 	log.Debug("volume update requested by hook")
 
 	// currently UpdateVolume() response is empty...
@@ -1132,7 +1098,7 @@ func (c *Client) doUpdateVolume(
 			// expired for the CO to [presumably] retry.
 			return nil, nil
 		case codes.InvalidArgument:
-			log.Errorf("volume update refused by LB on bad arg: %s", st.Message())
+			log.Error("volume update refused by LB on bad arg", "error", st.Message())
 			return nil, status.Errorf(codes.Internal,
 				"failed to update volume %s on LB: %s", uuid, st.Message())
 		case codes.FailedPrecondition:
@@ -1144,8 +1110,7 @@ func (c *Client) doUpdateVolume(
 			// UpdateVolume() response - retry the whole thing and
 			// hope the logic above will weed out the bad states so
 			// we don't end up in an infinite loop:
-			log.Debugf("will retry volume update refused by LB on failed "+
-				"precondition: %s", st.Message())
+			log.Debug("will retry volume update refused by LB on failed precondition", "messsage", st.Message())
 		default:
 			return badError("update", "on", err)
 		}
@@ -1219,17 +1184,17 @@ func (c *Client) GetSnapshotByName(
 }
 
 func statusFromErr(
-	log *logrus.Entry, err error, format string, args ...interface{},
+	log *slog.Logger, err error, format string, args ...interface{},
 ) error {
 	st, ok := status.FromError(err)
 	if ok {
 		return status.Errorf(st.Code(), format+": "+st.Message(), args...)
 	}
-	log.WithFields(logrus.Fields{
-		"err-type": fmt.Sprintf("%T", err),
-		"err-msg":  err.Error(),
-		"err-ctx":  fmt.Sprintf(format, args...),
-	}).Errorf("LB API call failed with unexpected error type")
+	log.With(
+		"err-type", fmt.Sprintf("%T", err),
+		"err-msg", err.Error(),
+		"err-ctx", fmt.Sprintf(format, args...),
+	).Error("LB API call failed with unexpected error type")
 	return status.Errorf(codes.Unknown, format+": "+err.Error(), args...)
 }
 
@@ -1259,7 +1224,7 @@ func (c *Client) CreateSnapshot(
 		code := st.Code()
 		switch code { //nolint:exhaustive
 		case codes.InvalidArgument:
-			c.log.Errorf("create snapshot refused by LB on bad arg: %s", st.Message())
+			c.log.Error("create snapshot refused by LB on bad arg", "message", st.Message())
 			return nil, status.Errorf(codes.Internal,
 				"failed to create snapshot '%s' on LB: %s", name, st.Message())
 		case codes.FailedPrecondition:
@@ -1267,8 +1232,7 @@ func (c *Client) CreateSnapshot(
 			// upper layers to retry the whole thing and
 			// hope the logic above will weed out the bad states so
 			// we don't end up in an infinite loop:
-			c.log.Debugf("create snapshot refused by LB on failed "+
-				"precondition: %s", st.Message())
+			c.log.Debug("create snapshot refused by LB on failed precondition", "message", st.Message())
 			return nil, status.Errorf(codes.Unavailable,
 				"create snapshot (%s) transiently failed", name)
 		}
@@ -1281,16 +1245,15 @@ func (c *Client) CreateSnapshot(
 	}
 	uuid := lbSnap.UUID
 
-	log = c.log.WithFields(logrus.Fields{
-		"snap-name": lbSnap.Name,
-		"snap-uuid": lbSnap.UUID,
-	})
+	log = c.log.With(
+		"snap-name", lbSnap.Name,
+		"snap-uuid", lbSnap.UUID,
+	)
 
 	switch lbSnap.State {
 	case lb.SnapshotDeleting,
 		lb.SnapshotFailed:
-		log.Warnf("LB snapshot creation returned volume in unexpected state '%s' (%d)",
-			lbSnap.State, lbSnap.State)
+		log.Warn("LB snapshot creation returned volume in unexpected state", "state", lbSnap.State)
 		return nil, status.Errorf(codes.Internal,
 			"LB created snapshot '%s' in inappropriate state '%s' (%d)",
 			name, lbSnap.State, lbSnap.State)
@@ -1333,8 +1296,7 @@ func (c *Client) CreateSnapshot(
 			return false, status.Errorf(codes.Aborted,
 				"snapshot appears to have been deleted in parallel")
 		case lb.SnapshotFailed:
-			log.Warnf("got bad snapshot from LB after create: '%s' is in state %s (%d)",
-				name, lbSnap.State, lbSnap.State)
+			log.Warn("got bad snapshot from LB after create in state", "name", name, "state", lbSnap.State)
 			return false, status.Errorf(codes.Unavailable,
 				"LB failed to create volume '%s', try again later", name)
 		case lb.SnapshotAvailable:
@@ -1373,7 +1335,7 @@ func (c *Client) DeleteSnapshot(
 		code := st.Code()
 		switch code { //nolint:exhaustive
 		case codes.InvalidArgument:
-			c.log.Errorf("delete snapshot refused by LB on bad arg: %s", st.Message())
+			c.log.Error("delete snapshot refused by LB on bad arg", "error", st.Message())
 			return status.Errorf(codes.Internal,
 				"failed to delete snapshot %s on LB: %s", uuid, st.Message())
 		case codes.FailedPrecondition:
@@ -1381,8 +1343,7 @@ func (c *Client) DeleteSnapshot(
 			// upper layers to retry the whole thing and
 			// hope the logic above will weed out the bad states so
 			// we don't end up in an infinite loop:
-			c.log.Debugf("delete snapshot refused by LB on failed "+
-				"precondition: %s", st.Message())
+			c.log.Debug("delete snapshot refused by LB on failed precondition", "message", st.Message())
 			return status.Errorf(codes.Unavailable,
 				"delete snapshot (%s) transiently failed", uuid.String())
 		}
@@ -1402,22 +1363,20 @@ func (c *Client) DeleteSnapshot(
 			return false, err
 		}
 
-		log := c.log.WithFields(logrus.Fields{
-			"snap-name": lbSnap.Name,
-			"snap-uuid": lbSnap.UUID,
-		})
+		log := c.log.With(
+			"snap-name", lbSnap.Name,
+			"snap-uuid", lbSnap.UUID,
+		)
 
 		switch lbSnap.State {
 		case lb.SnapshotAvailable:
 			return false, nil
 		case lb.SnapshotCreating:
-			log.Warnf("got snapshot in unexpected state from LB after delete: %s (%d)",
-				lbSnap.State, lbSnap.State)
+			log.Warn("got snapshot in unexpected state from LB after delete", "state", lbSnap.State)
 			return false, status.Errorf(codes.Unavailable,
 				"LB failed to delete snapshot '%s', try again later", lbSnap.Name)
 		case lb.SnapshotFailed:
-			log.Warnf("got snapshot in unexpected state from LB after delete: %s (%d)",
-				lbSnap.State, lbSnap.State)
+			log.Warn("got snapshot in unexpected state from LB after delete", "state", lbSnap.State)
 			fallthrough
 		case lb.SnapshotDeleting:
 			return true, nil
@@ -1493,8 +1452,7 @@ func (c *Client) lbSnapshotFromGRPC(
 			mgmt.Snapshot_Unknown,
 			mgmt.Snapshot_Failed:
 		default:
-			c.log.Warnf("got odd snapshot from LB: '%s' was successfully created, "+
-				"but lacks creation timestamp", snap.Name)
+			c.log.Warn("got odd snapshot from LB: '%s' was successfully created, but lacks creation timestamp", "name", snap.Name)
 		}
 	}
 

--- a/pkg/lb/lbgrpc/client_test.go
+++ b/pkg/lb/lbgrpc/client_test.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
+	"log/slog"
 	"math"
 	"math/rand"
 	"os"
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	guuid "github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -72,7 +71,7 @@ var (
 	logPath         string // path to file to store the log, '-' for stderr.
 	jwtPath         string // path to JWT token to use for authN to LightOS API.
 
-	log     = logrus.New()
+	log     = slog.Default()
 	cluster *clusterInfo   // if nil - no cluster info JSON specified
 	targets endpoint.Slice // filled in from `addrs` or `cluster`
 	jwt     string         // contents of file at `jwtPath`
@@ -133,27 +132,6 @@ func TestMain(m *testing.M) {
 	} else {
 		flagDie("path to valid 'system:cluster-admin' role JWT for authentication " +
 			"to the cluster mgmt endpoint must be specified")
-	}
-	if logPath == "" {
-		log.SetOutput(io.Discard)
-		log.SetLevel(logrus.PanicLevel)
-	} else {
-		log.SetFormatter(&logrus.TextFormatter{
-			FullTimestamp:   true,
-			TimestampFormat: "2006-01-02T15:04:05.000000-07:00",
-		})
-		log.SetLevel(logrus.DebugLevel)
-		if logPath != "-" {
-			f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-			if err != nil {
-				flagDie("failed to create log file '%s': %s", logPath, err)
-			}
-			defer func() {
-				f.Sync()
-				f.Close()
-			}()
-			log.SetOutput(f)
-		}
 	}
 
 	os.Exit(m.Run())

--- a/test/csi-sanity/csi-sanity_test.go
+++ b/test/csi-sanity/csi-sanity_test.go
@@ -41,7 +41,6 @@ func TestCSISanity(t *testing.T) {
 		DefaultFS:     "ext4",
 		LogLevel:      "info",
 		LogRole:       "node",
-		LogFormat:     "json",
 		LogTimestamps: false,
 		Transport:     "tcp",
 		SquelchPanics: false,


### PR DESCRIPTION
Logrus is not very well maintained and proven to be slow and allocates. Slog is part of go stdlib since go-1.21 and is known to be fast and does not allocate.

See: https://betterstack.com/community/guides/logging/best-golang-logging-libraries/