### PR TITLE
Amita/mimic yogev/install helm as non root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 build: ## Build plugin binary.
-	$(GO_VARS) go build $(GO_VERBOSE) -a -ldflags '$(LDFLAGS)' -o deploy/$(BIN_NAME)
+	$(GO_VARS) go build $(GO_VERBOSE) -buildvcs=false -a -ldflags '$(LDFLAGS)' -o deploy/$(BIN_NAME)
 
 deploy/k8s:
 	mkdir -p deploy/k8s

--- a/deploy/helm/lb-csi-workload-examples/charts/block/templates/example-block-pod.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/block/templates/example-block-pod.yaml
@@ -2,7 +2,7 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  name: example-block-pod
+  name: {{ .Values.podName | quote }}
 spec:
 {{- if .Values.nodeSelector }}
   nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 4 }}
@@ -28,4 +28,4 @@ spec:
   volumes:
     - name: lb-csi-mount
       persistentVolumeClaim:
-        claimName: example-block-pvc
+        claimName: {{ .Values.pvcName | quote }}

--- a/deploy/helm/lb-csi-workload-examples/charts/block/templates/example-block-pvc.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/block/templates/example-block-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: example-block-pvc
+  name: {{ .Values.pvcName | quote }}
 spec:
   storageClassName: {{ .Values.global.storageClass.name | quote }}
   accessModes:
@@ -10,4 +10,4 @@ spec:
   volumeMode: Block
   resources:
     requests:
-      storage: 3Gi
+      storage: {{ .Values.storage | default "3Gi" }}

--- a/deploy/helm/lb-csi-workload-examples/charts/block/values.schema.json
+++ b/deploy/helm/lb-csi-workload-examples/charts/block/values.schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Values",
+    "type": "object",
+    "properties": {
+      "nodeSelector": {
+        "description": "selector fields on the node we want to deploy the POD",
+        "type": "object"
+      },
+      "nodeName": {
+        "description": "name of the node we want to deploy the POD",
+        "type": "string"
+      },
+      "pvcName": {
+        "description": "name of the PVC",
+        "type": "string",
+        "default": "example-block-pvc"
+      },
+      "podName": {
+        "description": "name of the POD",
+        "type": "string",
+        "default": "example-block-pod"
+      },
+      "storage": {
+        "description": "size of the PVC",
+        "type": "string",
+        "default": "3Gi"
+      }
+    },
+    "required": [
+    ]
+  }

--- a/deploy/helm/lb-csi-workload-examples/charts/block/values.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/block/values.yaml
@@ -1,3 +1,7 @@
 nodeSelector: {} # Optional
 nodeName: ""
+pvcName: example-block-pvc
+podName: example-block-pod
+storage: 3Gi
+
 

--- a/deploy/helm/lb-csi-workload-examples/charts/filesystem/templates/example-fs-pod.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/filesystem/templates/example-fs-pod.yaml
@@ -28,4 +28,4 @@ spec:
   volumes:
   - name: test-mnt
     persistentVolumeClaim:
-      claimName: "example-fs-pvc"
+      claimName:  {{ .Values.pvcName | quote }}

--- a/deploy/helm/lb-csi-workload-examples/charts/filesystem/templates/example-fs-pvc.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/filesystem/templates/example-fs-pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: example-fs-pvc
+  name: {{ .Values.pvcName | quote }}
 spec:
   storageClassName: {{ .Values.global.storageClass.name | quote }}
   accessModes:
@@ -9,4 +9,4 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 10Gi
+      storage: {{ .Values.storage | default "10Gi" }}

--- a/deploy/helm/lb-csi-workload-examples/charts/filesystem/values.schema.json
+++ b/deploy/helm/lb-csi-workload-examples/charts/filesystem/values.schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Values",
+    "type": "object",
+    "properties": {
+      "nodeSelector": {
+        "description": "selector fields on the node we want to deploy the POD",
+        "type": "object"
+      },
+      "nodeName": {
+        "description": "name of the node we want to deploy the POD",
+        "type": "string"
+      },
+      "pvcName": {
+        "description": "name of the PVC",
+        "type": "string",
+        "default": "example-fs-pvc"
+      },
+      "podName": {
+        "description": "name of the POD",
+        "type": "string",
+        "default": "example-fs-pod"
+      },
+      "storage": {
+        "description": "size of the PVC",
+        "type": "string",
+        "default": "3Gi"
+      }
+    },
+    "required": [
+    ]
+  }

--- a/deploy/helm/lb-csi-workload-examples/charts/filesystem/values.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/filesystem/values.yaml
@@ -1,2 +1,5 @@
 nodeSelector: {} # Optional
 nodeName: ""
+pvcName: example-fs-pvc
+podName: example-fs-pod
+storage: 10Gi

--- a/deploy/helm/lb-csi-workload-examples/charts/snaps/templates/00.snapshot-sc.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/snaps/templates/00.snapshot-sc.yaml
@@ -8,7 +8,7 @@ apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: example-snapshot-sc
-driver: csi.lightbitslabs.com
+driver: {{ (or .Values.snapshotStorageClass.driver "csi.lightbitslabs.com") }}
 deletionPolicy: Delete
 {{- if and .Values.global.jwtSecret.name .Values.global.jwtSecret.namespace }}
 parameters:

--- a/deploy/helm/lb-csi-workload-examples/charts/snaps/values.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/snaps/values.yaml
@@ -1,6 +1,7 @@
 enabled: false
 snapshotStorageClass:
   name: example-snapshot-sc
+  driver: csi.lightbitslabs.com
 pvcName: example-pvc
 stage: "" # required! one of ["example-pvc", "snapshot-from-pvc", "pvc-from-snapshot", "pvc-from-pvc"]
 kubeVersion: "" # required! example: v1.20, v1.22.5

--- a/deploy/helm/lb-csi-workload-examples/charts/storageclass/templates/storageclass.yaml
+++ b/deploy/helm/lb-csi-workload-examples/charts/storageclass/templates/storageclass.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Values.global.storageClass.name }}
-provisioner: csi.lightbitslabs.com
+provisioner: {{ (or .Values.global.storageClass.provisioner "csi.lightbitslabs.com") }}
 allowVolumeExpansion: true
 parameters:
   mgmt-endpoint: {{ (required "mgmtEndpoints field is required" .Values.global.storageClass.mgmtEndpoints) }}

--- a/deploy/helm/lb-csi-workload-examples/values.yaml
+++ b/deploy/helm/lb-csi-workload-examples/values.yaml
@@ -3,6 +3,7 @@
 global:
   storageClass:
     name: example-sc
+    provisioner: csi.lightbitslabs.com
     # Name of the LightOS project we want the plugin to target.
     projectName: default
     # LightOS cluster API endpoints
@@ -45,3 +46,4 @@ snaps:
   kubeVersion: ""
   snapshotStorageClass:
     name: example-snapshot-sc
+    driver: csi.lightbitslabs.com

--- a/deploy/helm/lb-csi/templates/_helpers.tpl
+++ b/deploy/helm/lb-csi/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/* Generate basic labels */}}
+{{- define "mychart.labels" }}
+generator: helm
+date: {{ now | htmlDate }}
+chart: {{ .Chart.Name }}
+version: {{ .Chart.Version }}
+{{- end }}
+
+{{/*
+Create a default fully qualified driver name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+if a driverNamePrefix is provided we will use that prefix
+else we will name the driver with the <namespace>.csi.lightbitslabs.com unless namespace==kube-system
+in which case we will name it csi.lightbitslabs.com
+*/}}
+{{- define "driver.fullname" -}}
+{{- if .Values.driverNamePrefix -}}
+{{- printf "%s.csi.lightbitslabs.com" .Values.driverNamePrefix | trunc 63 | trimSuffix "." -}}
+{{- else -}}
+{{- if eq .Release.Namespace "kube-system" -}}
+{{- "csi.lightbitslabs.com" -}}
+{{- else -}}
+{{- printf "%s.csi.lightbitslabs.com" .Release.Namespace | trunc 63 | trimSuffix "." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a LB_CSI_NODE_ID
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+returns $(KUBE_NODE_NAME).node.{{ .Release.Namespace }} unless namespace==kube-system
+in which case we will name it $(KUBE_NODE_NAME).node
+*/}}
+{{- define "driver.nodeid" -}}
+{{- if eq .Release.Namespace "kube-system" -}}
+{{- "$(KUBE_NODE_NAME).node" -}}
+{{- else -}}
+{{- printf "$(KUBE_NODE_NAME).node.%s" .Release.Namespace | trunc 63 | trimSuffix "." -}}
+{{- end -}}
+{{- end -}}
+{{- include "driver.nodeid" . }}

--- a/deploy/helm/lb-csi/templates/csidriver.yaml
+++ b/deploy/helm/lb-csi/templates/csidriver.yaml
@@ -6,7 +6,9 @@ apiVersion: storage.k8s.io/v1
 {{- end }}
 kind: CSIDriver
 metadata:
-  name: csi.lightbitslabs.com
+  name: {{ include "driver.fullname" . }}
+  labels:
+{{- include "mychart.labels" . | indent 4 }}
 spec:
   attachRequired: true
   podInfoOnMount: true

--- a/deploy/helm/lb-csi/templates/lb-csi-attacher-cluster-role.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-attacher-cluster-role.yaml
@@ -36,7 +36,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-attacher-runner
+  name: lb-external-attacher-runner-{{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -57,17 +57,19 @@ rules:
 #  - apiGroups: [""]
 #    resources: ["secrets"]
 #    verbs: ["get", "list"]
-
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-attacher-role
+  name: lb-csi-attacher-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerServiceAccountName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: external-attacher-runner
+  name: lb-external-attacher-runner-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/lb-csi/templates/lb-csi-controller.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-controller.yaml
@@ -45,6 +45,8 @@ spec:
             value: text
           - name: LB_CSI_LOG_TIME
             value: "true"
+          - name: LB_CSI_DRIVER_NAME
+            value: {{ include "driver.fullname" . }}
 {{- if .Values.rwx }}
           - name: LB_CSI_RWX
             value: {{ .Values.rwx | quote }}

--- a/deploy/helm/lb-csi/templates/lb-csi-external-resizer-cluster-role.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-external-resizer-cluster-role.yaml
@@ -1,12 +1,12 @@
-{{$kubeVersion := (or .Values.kubeVersion .Capabilities.KubeVersion.Version) | trimPrefix "v" }}
-{{if ( .Values.enableExpandVolume ) }}
+# {{$kubeVersion := (or .Values.kubeVersion .Capabilities.KubeVersion.Version) | trimPrefix "v" }}
+# {{if ( .Values.enableExpandVolume ) }}
 # RBAC: external-resizer -------------------------
 # Taken from: https://github.com/kubernetes-csi/external-resizer/blob/master/deploy/kubernetes/rbac.yaml
 # Resizer must be able to work with PVCs, PVs, SCs.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: lb-csi-external-resizer-runner-role
+  name: lb-csi-external-resizer-runner-role-{{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -29,14 +29,14 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: lb-csi-external-resizer-runner-binding
+  name: lb-csi-external-resizer-runner-binding-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerServiceAccountName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: lb-csi-external-resizer-runner-role
+  name: lb-csi-external-resizer-runner-role-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 {{ end }}

--- a/deploy/helm/lb-csi/templates/lb-csi-node.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-node.yaml
@@ -56,7 +56,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: LB_CSI_NODE_ID
-              value: $(KUBE_NODE_NAME).node
+              value: {{ include "driver.nodeid" .}}
             - name: LB_CSI_LOG_LEVEL
               value: debug
             - name: LB_CSI_LOG_ROLE
@@ -65,6 +65,8 @@ spec:
               value: text
             - name: LB_CSI_LOG_TIME
               value: "true"
+            - name: LB_CSI_DRIVER_NAME
+              value: {{ include "driver.fullname" . }}
 {{- if .Values.luksConfigDir }}
             - name: LB_CSI_LUKS_CONFIG_PATH
               value: {{ .Values.luksConfigDir | quote }}
@@ -98,20 +100,20 @@ spec:
               mountPath: {{ .Values.luksConfigDir | quote }}
 {{- end }}
         - name: csi-node-driver-registrar
-          image: {{ .Values.sidecarImageRegistry }}/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: {{ .Values.sidecarImageRegistry }}/sig-storage/csi-node-driver-registrar:v2.4.0
           args:
             - "--v=4"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.lightbitslabs.com /registration/csi.lightbitslabs.com-reg.sock"]
+          # lifecycle:
+          #   preStop:
+          #     exec:
+          #       command: ["/bin/sh", "-c", "rm -rf /registration/csi.lightbitslabs.com /registration/csi.lightbitslabs.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: {{ .Values.kubeletRootDir }}/plugins/csi.lightbitslabs.com/csi.sock
+              value: {{ .Values.kubeletRootDir }}/plugins/{{- include "driver.fullname" . }}/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -152,7 +154,7 @@ spec:
           type: DirectoryOrCreate
       - name: plugin-dir
         hostPath:
-          path: {{ .Values.kubeletRootDir }}/plugins/csi.lightbitslabs.com
+          path: {{ .Values.kubeletRootDir }}/plugins/{{- include "driver.fullname" . }}
           type: DirectoryOrCreate
       - name: pods-mount-dir
         hostPath:

--- a/deploy/helm/lb-csi/templates/lb-csi-provisioner-cluster-role.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-provisioner-cluster-role.yaml
@@ -5,7 +5,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-provisioner-runner
+  name: lb-external-provisioner-runner-{{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -42,14 +42,14 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-provisioner-role
+  name: lb-csi-provisioner-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerServiceAccountName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: external-provisioner-runner
+  name: lb-external-provisioner-runner-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 ---

--- a/deploy/helm/lb-csi/templates/rbac-csi-snapshotter.yaml
+++ b/deploy/helm/lb-csi/templates/rbac-csi-snapshotter.yaml
@@ -6,7 +6,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # rename if there are conflicts
-  name: external-snapshotter-runner
+  name: lb-external-snapshotter-runner-{{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -31,7 +31,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-snapshotter-role
+  name: lb-csi-snapshotter-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerServiceAccountName }}
@@ -39,7 +39,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   # change the name also here if the ClusterRole gets renamed
-  name: external-snapshotter-runner
+  name: lb-external-snapshotter-runner-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -47,7 +47,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: external-snapshotter-leaderelection
+  name: lb-external-snapshotter-leaderelection-{{ .Release.Namespace }}
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -57,7 +57,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-snapshotter-leaderelection
+  name: lb-external-snapshotter-leaderelection-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
@@ -65,7 +65,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: external-snapshotter-leaderelection
+  name: lb-external-snapshotter-leaderelection-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 {{- else if ($kubeVersion | semverCompare "< 1.20.0") }}
 # taken from: https://github.com/kubernetes-csi/external-snapshotter/blob/release-3.0/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -74,7 +74,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # rename if there are conflicts
-  name: external-snapshotter-runner
+  name: lb-external-snapshotter-runner-{{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -100,7 +100,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-snapshotter-role
+  name: lb-csi-snapshotter-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.controllerServiceAccountName }}
@@ -108,7 +108,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   # change the name also here if the ClusterRole gets renamed
-  name: external-snapshotter-runner
+  name: lb-external-snapshotter-runner-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -116,7 +116,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: external-snapshotter-leaderelection
+  name: lb-external-snapshotter-leaderelection-{{ .Release.Namespace }}
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -126,7 +126,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-snapshotter-leaderelection
+  name: lb-external-snapshotter-leaderelection-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
@@ -134,7 +134,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: external-snapshotter-leaderelection
+  name: lb-external-snapshotter-leaderelection-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- end }}

--- a/deploy/helm/lb-csi/values.schema.json
+++ b/deploy/helm/lb-csi/values.schema.json
@@ -64,6 +64,10 @@
       "description": "LightOS API JWT to mount as volume for controller and node pods.",
       "type": "array"
     },
+    "driverNamePrefix": {
+      "description": "Provide a custom prefix for the driver. for example if provided - `mydriver` driver will be named: `mydriver.csi.lightbitslabs.com`",
+      "type": "string"
+    },
     "luksConfigDir": {
       "description": "Path to host folder that will be mounted to plugin for reading luks_config.yaml",
       "type": "string"

--- a/deploy/helm/lb-csi/values.yaml
+++ b/deploy/helm/lb-csi/values.yaml
@@ -12,6 +12,7 @@ discoveryClientImage: "lb-nvme-discovery-client:1.19.0"
 controllerServiceAccountName: lb-csi-ctrl-sa
 nodeServiceAccountName: lb-csi-node-sa
 kubeletRootDir: /var/lib/kubelet
+driverNamePrefix: ""
 #luksConfigDir: /etc/lb-csi-luks-config
 rwx: false
 #registryUsername: ""

--- a/docs/src/CHANGELOG/CHANGELOG-1.8.0.md
+++ b/docs/src/CHANGELOG/CHANGELOG-1.8.0.md
@@ -32,3 +32,4 @@ https://github.com/LightBitsLabs/los-csi/tree/duros/docs/upgrade
 - Add v1.22 support.
 - Extract Snapshot-Controller and CRDs deployment to it's own Helm Chart. Remove the deployment of the Snapshot-Controller as a sidecar
   and deploy it as a stand alone deployment.
+- Add support for running LightOS CSI plugin side-by-side on the same kubernetes cluster in different namespaces.

--- a/docs/src/plugin_deployment/plugin_deployment_using_helm.md
+++ b/docs/src/plugin_deployment/plugin_deployment_using_helm.md
@@ -55,5 +55,6 @@ helm/lb-csi
 | enableSnapshotVolume               | true                                    | Allow volume snapshot feature support         |
 | kubeletRootDir                     | /var/lib/kubelet                        | Kubelet root directory. (change only k8s deployment is different from default)      |
 | kubeVersion                        | ""                                      | Target K8s version for offline manifests rendering (overrides .Capabilities.Version)|
-| jwtSecret                          | []                                      | LightOS API JWT to mount as volume for controller and node pods.                    |
+| jwtSecret                          | []                                      | LightOS API JWT to mount as volume for controller and node pods.
+| driverNamePrefix                   | []                                      | Provide a custom prefix for the driver. for example if provided - `mydriver` driver will be named: `mydriver.csi.lightbitslabs.com`                    |                    |
 

--- a/main.go
+++ b/main.go
@@ -96,11 +96,14 @@ var defaults = driver.Config{
 	Transport:     "tcp",
 	SquelchPanics: false,
 	PrettyJSON:    false,
+	DriverName:    driver.DefaultDriverName,
 }
 
 var (
 	nodeID = flag.StringP("node-id", "n", "",
 		"Cluster Node ID, see $LB_CSI_NODE_ID.")
+	driverName = flag.StringP("driver-name", "d", "",
+		"DriverName, see $LB_CSI_DRIVER_NAME.")
 	endpoint = flag.StringP("endpoint", "e", "",
 		"CSI endpoint, see $CSI_ENDPOINT.")
 	defaultFS = flag.StringP("default-fs", "F", "",
@@ -227,6 +230,7 @@ func main() {
 		LUKSCfgPath: pickStr(*luksCfgPath, "LB_CSI_LUKS_CONFIG_PATH",
 			defaults.LUKSCfgPath),
 		JWTPath:       pickStr(*jwtPath, "LB_CSI_JWT_PATH", defaults.JWTPath),
+		DriverName:    pickStr(*driverName, "LB_CSI_DRIVER_NAME", defaults.DriverName),
 		NodeID:        pickStr(*nodeID, "LB_CSI_NODE_ID", defaults.NodeID),
 		Endpoint:      pickStr(*endpoint, "CSI_ENDPOINT", defaults.Endpoint),
 		DefaultFS:     pickStr(*defaultFS, "LB_CSI_DEFAULT_FS", defaults.DefaultFS),

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// q.v. https://github.com/container-storage-interface/spec/blob/v1.0.0/spec.md#getplugininfo
-	driverName = "csi.lightbitslabs.com"
+	DefaultDriverName = "csi.lightbitslabs.com"
 
 	logTimestampFmt = "2006-01-02T15:04:05.000000-07:00"
 )
@@ -95,6 +95,7 @@ type Config struct {
 	SquelchPanics bool
 	PrettyJSON    bool
 	RWX           bool
+	DriverName    string
 }
 
 type Driver struct {
@@ -144,6 +145,9 @@ type Driver struct {
 	// mechanisms (e.g. K8s Secrets that can be exposed to the LB CSI plugin
 	// as files through the pod volumes mechanism).
 	jwt string
+
+	// driverName is the name of the driver
+	driverName string
 
 	// rwx states that the plugin will expose AccessMode_MULTI_NODE_MULTI_WRITER
 	// capability for all volumes.
@@ -228,6 +232,7 @@ func New(cfg Config) (*Driver, error) { //nolint:gocritic
 		nodeID:        cfg.NodeID,
 		transport:     cfg.Transport,
 		squelchPanics: cfg.SquelchPanics,
+		driverName:    cfg.DriverName,
 		luksCfgFile:   filepath.Join(cfg.LUKSCfgPath, DefaultLUKSCfgFileName),
 		rwx:           cfg.RWX,
 	}
@@ -289,7 +294,7 @@ func New(cfg Config) (*Driver, error) { //nolint:gocritic
 	}
 	d.log = logger.WithFields(extraFields)
 	d.log.WithFields(logrus.Fields{
-		"driver-name":      driverName,
+		"driver-name":      cfg.DriverName,
 		"config":           fmt.Sprintf("%+v", cfg),
 		"backends":         strings.Join(backend.ListBackends(), ", "),
 		"version-rel":      version,

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -14,7 +14,7 @@ func (d *Driver) GetPluginInfo( //revive:disable-line:unused-receiver
 	_ context.Context, _ *csi.GetPluginInfoRequest,
 ) (*csi.GetPluginInfoResponse, error) {
 	return &csi.GetPluginInfoResponse{
-		Name:          driverName,
+		Name:          d.driverName,
 		VendorVersion: version,
 	}, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running multiple CSI drivers side-by-side in different namespaces within the same Kubernetes cluster.
  - Introduced configurable driver name and node ID, with options to set via Helm values, environment variables, or command-line flags.
  - Added Helm chart options for customizing resource names, PVC names, pod names, and storage sizes.

- **Improvements**
  - Enhanced Helm charts with dynamic resource naming and namespace scoping for RBAC and driver resources.
  - Updated documentation to reflect new side-by-side deployment and driver name customization features.

- **Chores**
  - Added schema validation files for Helm chart values.
  - Updated build process to exclude VCS information from binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->