### PR TITLE
fix: explicitly specify fsType in StorageClass example template

### DIFF
--- a/deploy/helm/lb-csi-workload-examples/values.yaml
+++ b/deploy/helm/lb-csi-workload-examples/values.yaml
@@ -12,6 +12,8 @@ global:
     compression: disabled
     qosPolicyName: ""
     host-encryption: disabled
+    # The csi.storage.k8s.io/fstype parameter is optional. The values allowed are ext4 or xfs. The default value is ext4.
+    fsType: "ext4"
   jwtSecret:
     name: example-secret
     namespace: default
@@ -20,8 +22,6 @@ global:
 # subchart workloads:
 storageclass:
   enabled: false
-  # The csi.storage.k8s.io/fstype parameter is optional. The values allowed are ext4 or xfs. The default value is ext4.
-  fstype: ""
 block:
   enabled: false
   nodeSelector: {}


### PR DESCRIPTION
today we give helm templates as examples for generating StorageClasses for los-csi. this exmaple is missing a key flag csi.storage.k8s.io/fstype when we specify the fsType flag, so k8s will not configure fsGroup settings if this flag is missing from StorageClass.

actually there are 2 issues: first - the default value is empty (assuming ext4) but it will result in us not specifiying the csi.storage.k8s.io/fstype param. second - there was a typo in the fstype/fsType field (uppercase T) causing the template never to render this field.

issue: LBM1-20579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default filesystem type for the storage class to "ext4" in the configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->