### PR TITLE
Makefile: delete helm templates of old deprecated csi versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ endif
 TTY=$(if $(shell [ -t 0 ] && echo 1),-it, )
 Q := $(if $(V), ,@)
 
+KUBE_VERSION=v1.33.0
+
 override BIN_NAME := lb-csi-plugin
 
 override HELM_VERSION := v3.18.0
@@ -210,168 +212,6 @@ lb-csi-manifests: verify_image_registry deploy/k8s
 		--set allowExpandVolume=true \
 		--set enableSnapshot=true \
 		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.17 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.17.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.17 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.17-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.18 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.18.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.18 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.18-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.19 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.19.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.19 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.19-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.20 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.20.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.20 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.20-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.21 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.21.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.21 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.21-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.22 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.22.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.22 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.22-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.23 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.23.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.23 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.23-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.24 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.24.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.24 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.24-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
-		--set kubeVersion=v1.25 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.25.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set kubeVersion=v1.25 \
-		--set imageRegistry=$(DOCKER_REGISTRY) \
-		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
-		--set image=$(FULL_REPO_NAME_WITH_TAG) \
-		--set discoveryClientImage=$(DISCOVERY_CLIENT_FULL_REPO_NAME_WITH_TAG) > deploy/k8s/lb-csi-plugin-k8s-v1.25-dc.yaml
-	helm template deploy/helm/lb-csi/ \
-		--namespace=kube-system \
-		--set allowExpandVolume=true \
-		--set enableSnapshot=true \
-		--set discoveryClientInContainer=false \
 		--set kubeVersion=v1.26 \
 		--set imageRegistry=$(DOCKER_REGISTRY) \
 		--set sidecarImageRegistry=$(SIDECAR_DOCKER_REGISTRY) \
@@ -543,23 +383,23 @@ examples_manifests: deploy/examples
 		--set preprovisioned.storage=1Gi \
 		deploy/helm/lb-csi-workload-examples > deploy/examples/preprovisioned-block-workload.yaml
 	helm template --set snaps.enabled=true \
-		--set snaps.kubeVersion=v1.24.0 \
+		--set snaps.kubeVersion=$(KUBE_VERSION) \
 		--set snaps.stage=snapshot-class \
 		deploy/helm/lb-csi-workload-examples > deploy/examples/snaps-example-snapshot-class.yaml
 	helm template --set snaps.enabled=true \
-		--set snaps.kubeVersion=v1.24.0 \
+		--set snaps.kubeVersion=$(KUBE_VERSION) \
 		--set snaps.stage=example-pvc \
 		deploy/helm/lb-csi-workload-examples > deploy/examples/snaps-example-pvc-workload.yaml
 	helm template --set snaps.enabled=true \
-		--set snaps.kubeVersion=v1.24.0 \
+		--set snaps.kubeVersion=$(KUBE_VERSION) \
 		--set snaps.stage=snapshot-from-pvc \
 		deploy/helm/lb-csi-workload-examples > deploy/examples/snaps-snapshot-from-pvc-workload.yaml
 	helm template --set snaps.enabled=true \
-		--set snaps.kubeVersion=v1.24.0 \
+		--set snaps.kubeVersion=$(KUBE_VERSION) \
 		--set snaps.stage=pvc-from-snapshot \
 		deploy/helm/lb-csi-workload-examples > deploy/examples/snaps-pvc-from-snapshot-workload.yaml
 	helm template --set snaps.enabled=true \
-		--set snaps.kubeVersion=v1.24.0 \
+		--set snaps.kubeVersion=$(KUBE_VERSION) \
 		--set snaps.stage=pvc-from-pvc \
 		deploy/helm/lb-csi-workload-examples > deploy/examples/snaps-pvc-from-pvc-workload.yaml
 


### PR DESCRIPTION


**PR dependencies**  
<!--
List any dependent PRs in any repositories that must be merged before this one.
Include valid links to those PRs between the tags below without modifying the tags.
-->
<!-- PR_DEPS_START -->
https://github.com/LightBitsLabs/testOSterone/pull/1645
https://github.com/LightBitsLabs/systests/pull/10841
<!-- PR_DEPS_END -->


**Jira Ticket**  
Issue: LBM1-37851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated manifest generation to support only Kubernetes versions v1.26 through v1.33.
  - Updated example snapshot workloads to use Kubernetes version v1.33.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->