### PR TITLE
fix: allowPrivilegeEscalation for initContainer to use sudo

### DIFF
--- a/deploy/helm/lb-csi/templates/lb-csi-node.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-node.yaml
@@ -33,10 +33,18 @@ spec:
           - >-
             [ -e /sys/module/nvme_tcp ] &&
             modinfo nvme_tcp ||
-            { modinfo nvme_tcp && modprobe nvme_tcp ; } ||
+            { modinfo nvme_tcp && sudo modprobe nvme_tcp ; } ||
             { echo "FAILED to load nvme-tcp kernel driver" && exit 1 ; }
           securityContext:
+            allowPrivilegeEscalation: true
             privileged: true
+            capabilities:
+              add:
+              - "SYS_ADMIN"
+{{- if .Values.runAsUser }}
+            runAsUser: {{ .Values.runAsUser }}
+            # runAsGroup: {{ .Values.runAsGroup }} # Optional GID
+{{- end }}
           volumeMounts:
             - name: modules-dir
               mountPath: /lib/modules


### PR DESCRIPTION
init-container now runs as non-root user.
we need to run sudo in order to run modprobe.
we need to grant permissions to do that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running the init container with a specific user, configurable via deployment settings.

- **Enhancements**
  - Improved security context for the init container, allowing privilege escalation and adding required system capabilities for kernel module loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->