### PR TITLE
lb-csi-attacher-cluster-role.yaml: rename external-attacher-runner ba…

### DIFF
--- a/deploy/helm/lb-csi/templates/lb-csi-attacher-cluster-role.yaml
+++ b/deploy/helm/lb-csi/templates/lb-csi-attacher-cluster-role.yaml
@@ -15,7 +15,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: lb-csi-external-attacher-runner
+  name: external-attacher-runner
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -48,7 +48,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: lb-csi-external-attacher-runner
+  name: external-attacher-runner
   apiGroup: rbac.authorization.k8s.io
 
 ---


### PR DESCRIPTION
…ck to original name

changing the name is causes csi plugin upgrade issues

issue: no-issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated resource names for certain roles and bindings to improve consistency. No changes to permissions or access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->