### PR TITLE
Makefile: Generate ubi9 based image deployment bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,6 +444,8 @@ bundle: verify_image_registry manifests examples_manifests helm_package
 	$(Q)tar -C deploy -czvf build/lb-csi-bundle-$(TAG).tar.gz \
 		k8s examples helm/charts lightos-patcher
 
+# reset FULL_REPO_NAME_WITH_TAG to generate bundle for UBI9 image
+bundle-ubi9: FULL_REPO_NAME_WITH_TAG := $(FULL_REPO_NAME_WITH_TAG_UBI)
 bundle-ubi9: verify_image_registry manifests examples_manifests helm_package
 	$(Q)if [ -z "$(DOCKER_REGISTRY)" ] ; then echo "DOCKER_REGISTRY not set, can't generate bundle" ; exit 1 ; fi
 	$(Q)mkdir -p ./build


### PR DESCRIPTION
current (make docker-bundle-ubi9)  for UBI bundles doesn’t create correct image bundles, deployment manifest points to non-ubi images, this will fix this issue. 

Issue: LBM1-38645

Test
 invoking target generates bundles pointing to correct images. This target is used for Openshift environment and currently not part of CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Makefile target to generate a bundle specifically for the UBI9 image variant, producing a tarball with a UBI9-specific name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->