### PR TITLE
fix: update snapshot-controller image

### DIFF
--- a/deploy/helm/snapshot-controller-4/Chart.yaml
+++ b/deploy/helm/snapshot-controller-4/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: snapshot-controller-4
-version: 0.12.0
+version: 0.13.0
 description: Deploy snapshot-controller for K8s version >= v1.20
-appVersion: 6.2.1
+appVersion: 8.2.0
 home: https://github.com/lightbitslabs/los-csi
 icon: https://www.lightbitslabs.com/wp-content/uploads/2018/08/cropped-header-logo-32x32.png
 maintainers:

--- a/deploy/helm/snapshot-controller-4/templates/setup-snapshot-controller.yaml
+++ b/deploy/helm/snapshot-controller-4/templates/setup-snapshot-controller.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
+          image: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
           args:
             - "--v=5"
             - "--leader-election=true"


### PR DESCRIPTION
align snapshot-controller image to match csi-snapshotter

Related PR:
https://github.com/LightBitsLabs/systests/pull/11657

issue: LBM1-19818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated snapshot-controller to v8.2.0 (previously v6.1.0) in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->