### PR TITLE
docs: reference discovery-client connect-all fix in v1.23.0 changelog

### DIFF
--- a/docs/src/CHANGELOG/CHANGELOG-v1.23.0.md
+++ b/docs/src/CHANGELOG/CHANGELOG-v1.23.0.md
@@ -29,3 +29,4 @@ https://github.com/LightBitsLabs/los-csi/tree/v1.23.0/docs/src/upgrade
 
 - Renamed the `snapshot-controller-4` chart to `snapshot-controller` and removed the deprecated `snapshot-controller-3` chart.
 - Updated the snapshot-controller.
+- Fixed a discovery-client issue that could cause the manual `connect-all` NVMe connection command to fail unexpectedly.


### PR DESCRIPTION
issue: LBM1-46382

Follow-up to #106. The v1.23.0 CSI release ships a discovery-client fix that was not called out in `CHANGELOG-v1.23.0.md`.

This adds a Highlights entry for the discovery-client fix for a nil pointer dereference (NPD) that could panic command-line NVMe operations such as `connect-all` when no configuration was provided.

Referenced change: discovery-client commit [`c965b6c`](https://github.com/LightBitsLabs/discovery-client/commit/c965b6c8d067c88e690b679c87e93ac26584d84e) — *nvme_client: fix nil pointer dereference in connect-all*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause the manual `connect-all` NVMe connection command to fail unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->