### PR TITLE
docs: install snapshot-controller from helm repo

### DIFF
--- a/docs/src/plugin_deployment/plugin_deployment_using_lightbits_helm_repository.md
+++ b/docs/src/plugin_deployment/plugin_deployment_using_lightbits_helm_repository.md
@@ -24,7 +24,7 @@ helm search repo lightbits-helm-repo
 NAME                                            CHART VERSION   APP VERSION     DESCRIPTION
 lightbits-helm-repo/lb-csi-plugin                 0.21.0          v1.23.0          Helm Chart for Lightbits CSI Plugin.
 lightbits-helm-repo/lb-csi-workload-examples      0.21.0          v1.23.0          Helm Chart for Lightbits CSI Workload Examples.
-lightbits-helm-repo/snapshot-controller           0.18.0          4.2.1           Deploy snapshot-controller for K8s version >= v1.20
+lightbits-helm-repo/snapshot-controller           0.13.0          8.2.0           Deploy snapshot-controller for K8s version >= v1.20
 ```
 
 
@@ -38,11 +38,14 @@ Kubernetes admins should bundle and deploy the controller and CRDs as part of th
 
 If your cluster does not come pre-installed with the correct components, you may manually install these components by executing these [steps](https://kubernetes-csi.github.io/docs/snapshot-controller.html#deployment)
 
-For convenience we provide Helm Charts to deploy snapshot-controller, CRDs and RBAC rules:
+For convenience we provide a Helm Chart that deploys the snapshot-controller, its CRDs and RBAC rules. Verify the published version, then install it (into the `kube-system` namespace):
 
 ```bash
-k8s/
-lightbits-helm-repo/snapshot-controller           0.18.0          4.2.1           Deploy snapshot-controller for K8s version >= v1.20
+helm search repo lightbits-helm-repo/snapshot-controller
+NAME                                      CHART VERSION   APP VERSION   DESCRIPTION
+lightbits-helm-repo/snapshot-controller   0.13.0          8.2.0         Deploy snapshot-controller for K8s version >= v1.20
+
+helm install -n kube-system snapshot-controller lightbits-helm-repo/snapshot-controller
 ```
 
 Deploy these resources once before installing `lb-csi-plugin`.


### PR DESCRIPTION
**PR description**
The Lightbits helm-repository deployment guide references the snapshot-controller chart but never tells the user how to install it. The install code block was a mangled paste (a `k8s/` tree fragment plus a `helm search` output line), so a reader cannot follow it, and the version it listed (`0.18.0` / `4.2.1`) matched neither the bundle nor what is in Cloudsmith.

This is the consumer-facing half of LBM1-44303: publishing the chart to Cloudsmith (companion PR — lbcitests #1745) is only useful if the docs can actually guide someone to install it.

This PR:
- Replaces the broken block with a real command, mirroring the `lb-csi-plugin` example just below it in the same file:
  `helm install -n kube-system snapshot-controller lightbits-helm-repo/snapshot-controller`
- Corrects the `helm search` version reference to the current chart (`0.13.0` / appVersion `8.2.0`).

**How was the PR tested?**
- Docs-only change; no code or tests.
- The install command targets the same repo the doc's own `helm repo add` step configures (`https://dl.lightbitslabs.com/public/lightos-csi/helm/charts/`) and mirrors the working `lb-csi-plugin` example in the same guide.
- Version reference (`0.13.0` / `8.2.0`) confirmed against `deploy/helm/snapshot-controller/Chart.yaml` on `origin/master`.
- Not runnable end-to-end until the chart is published to Cloudsmith (see companion PR), which is what makes this guide accurate.

**PR dependencies**
<!-- PR_DEPS_START -->
Depends-On: https://github.com/LightBitsLabs/lbcitests/pull/1745
<!-- PR_DEPS_END -->

**Jira Ticket**
Issue: LBM1-44303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated snapshot-controller Helm chart and application version information.
  * Added commands to verify the published chart and install it in the `kube-system` namespace.
  * Clarified deployment steps for Kubernetes clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->